### PR TITLE
strip exif data from images when they passthrough the endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const multerS3 = require('multer-s3')
 const morgan = require('morgan')
 const bodyParser = require('body-parser')
 const fetch = require('node-fetch')
+const ExifTransformer = require('exif-be-gone')
 
 const app = express()
 app.use(morgan('combined'))
@@ -23,7 +24,11 @@ const upload = multer({
     s3,
     bucket: 'koddsson-media',
     acl: 'public-read',
-    contentType: multerS3.AUTO_CONTENT_TYPE,
+    contentType(req, file, cb) {
+      multerS3.AUTO_CONTENT_TYPE(req, file, function(_, mime, outputStream) {
+        cb(null, mime, outputStream.pipe(new ExifTransformer({readableObjectMode: true, writableObjectMode: true})))
+      })
+    },
     key(request, file, cb) {
       console.log(file)
       cb(null, file.originalname)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1147,6 +1147,11 @@
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
+    "exif-be-gone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/exif-be-gone/-/exif-be-gone-1.0.0.tgz",
+      "integrity": "sha512-Df3doT6MeJ5/+8u4rgZv1cndJEehVbXEBI/eBCb1faO63XLet/aJJZkzCr01f+JPUNnTn+HZydpzWZmPGlk0CQ=="
+    },
     "express": {
       "version": "4.16.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "aws-sdk": "^2.306.0",
     "body-parser": "^1.18.3",
+    "exif-be-gone": "^1.0.0",
     "express": "^4.16.3",
     "morgan": "^1.9.0",
     "multer": "^1.3.1",


### PR DESCRIPTION
A very hacky way to access the filestream and attach a stream transformer that strips the EXIF data from the image as it goes through the middleware.

I didn't want to make a upstream patch to multer since it seems like they are working on a new streams API that would expose a lot of these by default.  Nothing has happened there since 2017 thought so it might be worth exploring different options here.